### PR TITLE
fix: `installCRDs` is deprecated, use `crds.enabled` instead

### DIFF
--- a/cert-manager-values.yaml
+++ b/cert-manager-values.yaml
@@ -1,0 +1,2 @@
+crds:
+  enabled: true

--- a/scripts/cert-manager.nu
+++ b/scripts/cert-manager.nu
@@ -6,7 +6,7 @@ def apply_certmanager [] {
         helm upgrade --install cert-manager cert-manager
             --repo https://charts.jetstack.io
             --namespace cert-manager --create-namespace
-            --set installCRDs=true --wait
+            ---values cert-manager-values.yaml --wait
     )
 
 }


### PR DESCRIPTION
Hi,

just trying out the demo and i found a litte deprecation warning.

This should fix it.

PS: Thanks for your great work!
